### PR TITLE
Ignore node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@siteglide/siteglide-cli",
-	"version": "1.10.1",
+	"version": "1.10.2",
 	"description": "A CLI for Making Website Management a Breeze",
 	"scripts": {
 		"postinstall": "node ./scripts/check-node-version.js",

--- a/siteglide-cli-archive.js
+++ b/siteglide-cli-archive.js
@@ -63,7 +63,7 @@ const makeArchive = (path, directory, program) => {
 	}
 
 	const releaseArchive = prepareArchive(path);
-	releaseArchive.glob('**/*', { cwd: directory, ignore: ['assets/**']}, { prefix: directory });
+	releaseArchive.glob('**/*', { cwd: directory, ignore: ['assets/**', '**/node_modules/**']}, { prefix: directory });
 
 	addModulesToArchive(releaseArchive).then(r => {
 		releaseArchive.finalize();

--- a/siteglide-cli-migrate.js
+++ b/siteglide-cli-migrate.js
@@ -72,7 +72,7 @@ const makeArchive = (path, directory) => {
 		if (path ==='./.tmp/assets.zip'){
 			releaseArchive.glob('**/**', { cwd: `${directory}/assets` });
 		}else{
-			releaseArchive.glob('**/*', { cwd: directory, ignore: ['assets/**'] }, { prefix: directory });
+			releaseArchive.glob('**/*', { cwd: directory, ignore: ['assets/**', '**/node_modules/**'] }, { prefix: directory });
 		}
 
 		releaseArchive.finalize();

--- a/siteglide-cli-watch.js
+++ b/siteglide-cli-watch.js
@@ -44,7 +44,7 @@ const isEmpty = filePath => {
 	return isEmpty;
 };
 const shouldBeSynced = (filePath) => {
-	return extensionAllowed(filePath) && isNotHidden(filePath) && isNotEmptyYML(filePath);
+	return extensionAllowed(filePath) && isNotHidden(filePath) && isNotEmptyYML(filePath) && isNotInNodeModules(filePath);
 };
 const isAssetsPath = (path) => path.startsWith('marketplace_builder/assets') || path.startsWith('marketplace_builder\\assets');
 let manifestFilesToAdd = [];
@@ -79,6 +79,10 @@ const isNotEmptyYML = filePath => {
 	}
 
 	return true;
+};
+
+const isNotInNodeModules = filePath => {
+	return !filePath.includes(`${path.sep}node_modules${path.sep}`);
 };
 
 CONCURRENCY = 3;


### PR DESCRIPTION
Hi @mattwalter91 ,

Adding `node_modules` to the ignore list for sync, deploy & migrate.

I had added this code locally for myself anyway, as I have node_modules inside a module folder for tailwind on a couple of sites, thought I'd PR this in as It will likely become more common as we figure out the tailwind setup on sites.

I have it currently set to not log anything to the console when any file within node_modules is saved in the directory so that the console isn't spammed if sync has been left on when npm i'ing in a module.

Not a huge priority to get this merged at the moment, as it's really only Wysi who do this method at the moment.