### PR TITLE
Add `staging-siteglide.com` to allowed platform URL check; bump to 1.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@siteglide/siteglide-cli",
-	"version": "1.10.2",
+	"version": "1.10.3",
 	"description": "A CLI for Making Website Management a Breeze",
 	"scripts": {
 		"postinstall": "node ./scripts/check-node-version.js",

--- a/siteglide-cli-add.js
+++ b/siteglide-cli-add.js
@@ -105,7 +105,8 @@ program
 		if(
 			(!params.url.includes('platform-os.com'))&&
 			(!params.url.includes('platformos.com'))&&
-			(!params.url.includes('uk-siteglide.com'))
+			(!params.url.includes('uk-siteglide.com'))&&
+			(!params.url.includes('staging-siteglide.com'))
 		){
 			logger.Error('Please use the platform URL to add the environment, not the vanity URL. For example: https://my-great-site.uk-siteglide.com/');
 		}


### PR DESCRIPTION
## What
- Extend platform URL validation in `siteglide-cli-add.js` to accept `staging-siteglide.com` alongside:
  - `platform-os.com`
  - `platformos.com`
  - `uk-siteglide.com`
- Bump package version to `1.10.3`.

## Why
Environments hosted on `*.staging-siteglide.com` were incorrectly treated as vanity URLs and blocked. This change updates the allow-list so staging platform URLs are recognised as valid.

## How
Add `!params.url.includes('staging-siteglide.com')` to the existing validation condition. No other behavioural changes.

## Risks & Considerations
- **Risk:** Low—broadens validation to another first-party domain.

## Testing
- ✅ `https://my-site.staging-siteglide.com/` now passes.
- ✅ `https://my-site.uk-siteglide.com/`, `https://my-site.platformos.com/`, and `https://my-site.platform-os.com/` continue to pass.
- ❌ Known vanity domains continue to fail as expected.

## Changelog
- Accept `*.staging-siteglide.com` as a valid platform URL when adding environments.
- Bump version to `1.10.3`.
